### PR TITLE
Set up Docker CD

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Check out repo
+        uses: actions/checkout@v3
       - name: Create secret files
         id: secret-files
         run: |
@@ -24,5 +26,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
+          context: .
           push: true
           tags: rodsan0/capstone-ss23:latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [ main, test ]
+    branches: [ main, docker-cd-setup ]
 
 jobs:
   prod-build:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,28 @@
+name: CI
+on:
+  push:
+    branches: [ main, test ]
+
+jobs:
+  prod-build:
+    name: Build Docker container for production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+      - name: Log in to Dockerhub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create secret files
+        id: secret-files
+        run: |
+          echo ${{ secrets.AUTH_JSON_SECRET_FILE }} | base64 -d > auth.json
+          echo ${{ secrets.DOT_ENV_SECRET_FILE }} | base64 -d > .env
+          echo ${{ secrets.SITE_PHP_SECRET_FILE }} | base64 -d > site.php
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: rodsan0/capstone-ss23:latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Create secret files
         id: secret-files
         run: |
-          echo "${{ secrets.AUTH_JSON_SECRET_FILE }}" | base64 -d > auth.json
-          echo "${{ secrets.DOT_ENV_SECRET_FILE }}" | base64 -d > .env
-          echo "${{ secrets.SITE_PHP_SECRET_FILE }}" | base64 -d > site.php
+          echo "${{ secrets.AUTH_JSON_SECRET_FILE }}" | base64 -di > auth.json
+          echo "${{ secrets.DOT_ENV_SECRET_FILE }}" | base64 -di > .env
+          echo "${{ secrets.SITE_PHP_SECRET_FILE }}" | base64 -di > site.php
       - name: Build and push
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Create secret files
         id: secret-files
         run: |
-          echo ${{ secrets.AUTH_JSON_SECRET_FILE }} | base64 -d > auth.json
-          echo ${{ secrets.DOT_ENV_SECRET_FILE }} | base64 -d > .env
-          echo ${{ secrets.SITE_PHP_SECRET_FILE }} | base64 -d > site.php
+          echo "${{ secrets.AUTH_JSON_SECRET_FILE }}" | base64 -d > auth.json
+          echo "${{ secrets.DOT_ENV_SECRET_FILE }}" | base64 -d > .env
+          echo "${{ secrets.SITE_PHP_SECRET_FILE }}" | base64 -d > site.php
       - name: Build and push
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
-          token: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Create secret files
         id: secret-files
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-apache
+FROM php:8.0-apache AS dev
 
 COPY . /var/www/capstone-ss23
 WORKDIR /var/www/capstone-ss23
@@ -12,3 +12,7 @@ RUN install-php-extensions gd pdo_mysql
 
 # make composer available
 COPY --from=composer:2.5.1 /usr/bin/composer /usr/bin/composer
+
+FROM dev AS prod
+
+CMD ./install_deps.sh && apache2-foreground

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
+      target: dev
     ports:
       - '${APP_PORT}:80'
     environment:


### PR DESCRIPTION
This PR adds a GitHub workflow to maintain a fresh copy of this repo on a private Dockerhub repo. This will allow us to unit test more easily, as well as enabling future Continuous Deployment to a dev server.